### PR TITLE
Add C++ parser and clang-format

### DIFF
--- a/lua/plugins/autoformatting.lua
+++ b/lua/plugins/autoformatting.lua
@@ -10,26 +10,27 @@ return {
 		local diagnostics = null_ls.builtins.diagnostics -- to setup linters
 
 		-- Formatters & linters for mason to install
-		require("mason-null-ls").setup({
-			ensure_installed = {
-				"prettier", -- ts/js formatter
-				"stylua", -- lua formatter
-				"eslint_d", -- ts/js linter
-				"shfmt", -- Shell formatter
-				"ruff", -- Python linter and formatter
-			},
-			automatic_installation = true,
-		})
+               require("mason-null-ls").setup({
+                       ensure_installed = {
+                               "prettier", -- ts/js formatter
+                               "stylua", -- lua formatter
+                               "eslint_d", -- ts/js linter
+                               "shfmt", -- Shell formatter
+                               "ruff", -- Python linter and formatter
+                               "clang-format", -- C/C++ formatter
+                       },
+                       automatic_installation = true,
+               })
 
-		local sources = {
-			diagnostics.checkmake,
-			formatting.prettier.with({ filetypes = { "html", "json", "yaml", "markdown" } }),
-			formatting.stylua,
-			formatting.shfmt.with({ args = { "-i", "4" } }),
-			formatting.terraform_fmt,
-			require("none-ls.formatting.ruff").with({ extra_args = { "--extend-select", "I" } }),
-			require("none-ls.formatting.ruff_format"),
-		}
+               local sources = {
+                       formatting.prettier.with({ filetypes = { "html", "json", "yaml", "markdown" } }),
+                       formatting.stylua,
+                       formatting.shfmt.with({ args = { "-i", "4" } }),
+                       formatting.terraform_fmt,
+                       formatting.clang_format,
+                       require("none-ls.formatting.ruff").with({ extra_args = { "--extend-select", "I" } }),
+                       require("none-ls.formatting.ruff_format"),
+               }
 
 		local augroup = vim.api.nvim_create_augroup("LspFormatting", {})
 		null_ls.setup({

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -303,8 +303,8 @@ return {
 		format_on_save = function(bufnr)
 			-- Disable "format_on_save lsp_fallback" for languages that don't
 			-- have a well standardized coding style. You can add additional
-			-- languages here or re-enable it for the disabled ones.
-			local disable_filetypes = { c = true, cpp = true }
+                       -- languages here or re-enable it for the disabled ones.
+                       local disable_filetypes = {}
 			if disable_filetypes[vim.bo[bufnr].filetype] then
 				return nil
 			else
@@ -314,13 +314,15 @@ return {
 				}
 			end
 		end,
-		formatters_by_ft = {
-			lua = { "stylua" },
-			-- Conform can also run multiple formatters sequentially
-			-- python = { "isort", "black" },
-			--
-			-- You can use 'stop_after_first' to run the first available formatter from the list
-			-- javascript = { "prettierd", "prettier", stop_after_first = true },
-		},
+               formatters_by_ft = {
+                       lua = { "stylua" },
+                       c = { "clang_format" },
+                       cpp = { "clang_format" },
+                       -- Conform can also run multiple formatters sequentially
+                       -- python = { "isort", "black" },
+                       --
+                       -- You can use 'stop_after_first' to run the first available formatter from the list
+                       -- javascript = { "prettierd", "prettier", stop_after_first = true },
+               },
 	},
 }

--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -5,7 +5,7 @@ return
 	main = 'nvim-treesitter.configs', -- Sets main module to use for opts
 	-- [[ Configure Treesitter ]] See `:help nvim-treesitter`
 	opts = {
-		ensure_installed = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc' },
+               ensure_installed = { 'bash', 'c', 'cpp', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc' },
 		-- Autoinstall languages that are not installed
 		auto_install = true,
 		highlight = {


### PR DESCRIPTION
## Summary
- install clang-format with mason-null-ls
- remove checkmake diagnostic
- enable clang-format in LSP formatting
- install cpp Treesitter parser

## Testing
- `nvim --headless +quit`
- `luacheck --version`


------
https://chatgpt.com/codex/tasks/task_e_68583677f3d4832a848aca38dea79205