### PR TITLE
Add missing Treesitter parsers

### DIFF
--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -5,7 +5,23 @@ return
 	main = 'nvim-treesitter.configs', -- Sets main module to use for opts
 	-- [[ Configure Treesitter ]] See `:help nvim-treesitter`
 	opts = {
-		ensure_installed = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc' },
+                ensure_installed = {
+                        'bash',
+                        'c',
+                        'diff',
+                        'html',
+                        'lua',
+                        'luadoc',
+                        'markdown',
+                        'markdown_inline',
+                        'query',
+                        'vim',
+                        'vimdoc',
+                        'cpp',
+                        'cmake',
+                        'make',
+                        'json',
+                },
 		-- Autoinstall languages that are not installed
 		auto_install = true,
 		highlight = {


### PR DESCRIPTION
## Summary
- extend `ensure_installed` list to include cpp, cmake, make and json

## Testing
- `nvim --headless -u NONE -c 'set rtp^=~/.local/share/nvim/lazy/nvim-treesitter' -c 'runtime! plugin/nvim-treesitter.lua' -c 'TSUpdateSync cpp cmake make json' +qa`

------
https://chatgpt.com/codex/tasks/task_e_68583ec7a38c832ab224024350bf9dde