### PR TITLE
Enable clang-format for C/C++

### DIFF
--- a/lua/plugins/autoformatting.lua
+++ b/lua/plugins/autoformatting.lua
@@ -27,6 +27,7 @@ return {
 			formatting.stylua,
 			formatting.shfmt.with({ args = { "-i", "4" } }),
 			formatting.terraform_fmt,
+			formatting.clang_format,
 			require("none-ls.formatting.ruff").with({ extra_args = { "--extend-select", "I" } }),
 			require("none-ls.formatting.ruff_format"),
 		}

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -304,7 +304,7 @@ return {
 			-- Disable "format_on_save lsp_fallback" for languages that don't
 			-- have a well standardized coding style. You can add additional
 			-- languages here or re-enable it for the disabled ones.
-			local disable_filetypes = { c = true, cpp = true }
+			local disable_filetypes = {}
 			if disable_filetypes[vim.bo[bufnr].filetype] then
 				return nil
 			else
@@ -316,6 +316,8 @@ return {
 		end,
 		formatters_by_ft = {
 			lua = { "stylua" },
+			c = { "clang_format" },
+			cpp = { "clang_format" },
 			-- Conform can also run multiple formatters sequentially
 			-- python = { "isort", "black" },
 			--


### PR DESCRIPTION
## Summary
- add `clang_format` to the formatting sources
- let C and C++ use clang-format by default
- allow formatting on save for C and C++
- fix indentation of newly added lines

## Testing
- `nvim --headless -c 'quitall'`


------
https://chatgpt.com/codex/tasks/task_e_685841824be4832aaf99bd573677b7bc